### PR TITLE
trying to support stage2 compiler

### DIFF
--- a/src/cert/asn1.zig
+++ b/src/cert/asn1.zig
@@ -89,7 +89,7 @@ pub const Kind = union(enum) {
         tag: Tag,
     },
     /// Allows the user how to decode the choice
-    choice: fn (decoder: *Decoder, id: u8) Decoder.Error!Value,
+    choice: *const fn (decoder: *Decoder, id: u8) Decoder.Error!Value,
     /// When the element can be ignored
     none,
 };
@@ -191,7 +191,7 @@ pub const Decoder = struct {
                         .choice => |callback| {
                             // decrease index to make the tag byte available again to the callback
                             self.index -= 1;
-                            return callback(self, @truncate(u3, tag_byte));
+                            return callback.*(self, @truncate(u3, tag_byte));
                         },
                         else => return error.InvalidTag,
                     }
@@ -455,7 +455,7 @@ test "Choice" {
         .{
             .with_schema = &.{
                 .{
-                    .choice = callback,
+                    .choice = &callback,
                 },
             },
         },

--- a/src/cert/asn1.zig
+++ b/src/cert/asn1.zig
@@ -191,7 +191,7 @@ pub const Decoder = struct {
                         .choice => |callback| {
                             // decrease index to make the tag byte available again to the callback
                             self.index -= 1;
-                            return callback.*(self, @truncate(u3, tag_byte));
+                            return callback(self, @truncate(u3, tag_byte));
                         },
                         else => return error.InvalidTag,
                     }

--- a/src/handshake.zig
+++ b/src/handshake.zig
@@ -579,7 +579,8 @@ test "Client Hello" {
     };
     // zig fmt: on
 
-    var fb_reader = std.io.fixedBufferStream(&data).reader();
+    var fbs = std.io.fixedBufferStream(&data);
+    var fb_reader = fbs.reader();
     var hasher = Sha256.init(.{});
     var hs_reader = handshakeReader(fb_reader, &hasher);
     const result = try hs_reader.decode();

--- a/src/tls.zig
+++ b/src/tls.zig
@@ -346,7 +346,7 @@ pub fn bytesToTypedSlice(comptime T: type, bytes: anytype) []const T {
     if (target_endianness == .Little) for (slice) |*element| {
         element.* = @byteSwap(IntType, element.*);
     };
-    return @bitCast([]const T, slice);
+    return @ptrCast([]const T, slice);
 }
 
 /// Keyshare represents the key exchange used to generate
@@ -477,7 +477,7 @@ pub const Extension = union(Tag) {
 
             switch (@intToEnum(Extension.Tag, tag_byte)) {
                 .supported_versions => return Extension{ .supported_versions = bytesToTypedSlice(u16, extension_data[1..]) },
-                .psk_key_exchange_modes => return Extension{ .psk_key_exchange_modes = @bitCast(
+                .psk_key_exchange_modes => return Extension{ .psk_key_exchange_modes = @ptrCast(
                     []const PskKeyExchangeMode,
                     extension_data[1..],
                 ) },
@@ -609,12 +609,12 @@ pub const KeyExchange = struct {
 pub const Curve = struct {
     /// Error which can occur when generating the public key
     pub const Error = crypto.errors.IdentityElementError;
-    genFn: fn (*Curve, [32]u8, *[32]u8) Error!void,
+    genFn: *const fn (*Curve, [32]u8, *[32]u8) Error!void,
 
     /// Generates a new public key from a given private key.
     /// Writes the output of the curve function to `public_key_out`.
     pub fn generateKey(self: *Curve, private_key: [32]u8, public_key_out: *[32]u8) Error!void {
-        try self.genFn(self, private_key, public_key_out);
+        try self.genFn.*(self, private_key, public_key_out);
     }
 };
 
@@ -622,7 +622,7 @@ pub const Curve = struct {
 /// to generate keys.
 pub const curves = struct {
     const _x25519 = struct {
-        var state = Curve{ .genFn = gen };
+        var state = Curve{ .genFn = &gen };
 
         fn gen(curve: *Curve, private_key: [32]u8, public_key_out: *[32]u8) !void {
             _ = curve;

--- a/src/tls.zig
+++ b/src/tls.zig
@@ -614,7 +614,7 @@ pub const Curve = struct {
     /// Generates a new public key from a given private key.
     /// Writes the output of the curve function to `public_key_out`.
     pub fn generateKey(self: *Curve, private_key: [32]u8, public_key_out: *[32]u8) Error!void {
-        try self.genFn.*(self, private_key, public_key_out);
+        try self.genFn(self, private_key, public_key_out);
     }
 };
 


### PR DESCRIPTION
Hi @Luukdegram, thanks for your efforts on this lib, I'm currently researching and trying to understand TLS1.3/QUIC and this is being really helpful resource to me!

I'm trying to support the stage2 compiler for your lib here, would appreciate it if you can give me any direction I could take to fix these compilation errors:

```
feilich/src/tls.zig:617:23: error: values of type 'fn(*tls.Curve, [32]u8, *[32]u8) error{IdentityElement}!void' must be comptime known, but operand value is runtime known
        try self.genFn.*(self, private_key, public_key_out);
            ~~~~~~~~~~^~
feilich/src/tls.zig:617:23: note: use '*const fn(*tls.Curve, [32]u8, *[32]u8) error{IdentityElement}!void' for a function pointer type
feilich/src/cert/asn1.zig:194:44: error: values of type 'fn(*cert.asn1.Decoder, u8) error{ContextSpecific,EndOfData,InvalidLength,InvalidTag,OutOfMemory}!cert.asn1.Value' must be comptime known, but operand value is runtime known
                            return callback.*(self, @truncate(u3, tag_byte));
                                   ~~~~~~~~^~
feilich/src/cert/asn1.zig:194:44: note: use '*const fn(*cert.asn1.Decoder, u8) error{ContextSpecific,EndOfData,InvalidLength,InvalidTag,OutOfMemory}!cert.asn1.Value' for a function pointer type
error: test...
error: The following command exited with error code 1:
```

If I use `main_tests.use_stage1 = true;` config on `build.zig` all tests are passing.

Thank you!